### PR TITLE
Add Minimize Down option

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -18,6 +18,7 @@ local DEFAULTS = {
         fontSize        = 11,
         panelOpen       = true,
         minimap         = { hide = false },
+        minimizeDown    = false,
         firstSeen       = false,
         modules         = {},
         moduleOrder     = {},

--- a/UI.lua
+++ b/UI.lua
@@ -250,12 +250,18 @@ function MR:BuildUI()
 
     local function ApplyMinimizeState()
         if MR.db.profile.minimized then
-            local left = f:GetLeft()
-            local top  = f:GetTop()
-            if left and top then
+            local left   = f:GetLeft()
+            local top    = f:GetTop()
+            local bottom = f:GetBottom()
+            if left and top and bottom then
                 f:ClearAllPoints()
-                f:SetPoint("TOPLEFT", UIParent, "BOTTOMLEFT", left, top)
-                MR.db.profile.position = { point = "TOPLEFT", relPoint = "BOTTOMLEFT", x = left, y = top }
+                if MR.db.profile.minimizeDown then
+                    f:SetPoint("BOTTOMLEFT", UIParent, "BOTTOMLEFT", left, bottom)
+                    MR.db.profile.position = { point = "BOTTOMLEFT", relPoint = "BOTTOMLEFT", x = left, y = bottom }
+                else
+                    f:SetPoint("TOPLEFT", UIParent, "BOTTOMLEFT", left, top)
+                    MR.db.profile.position = { point = "TOPLEFT", relPoint = "BOTTOMLEFT", x = left, y = top }
+                end
             end
             if MR.scroll       then MR.scroll:Hide()       end
             if MR._scrollBg    then MR._scrollBg:Hide()    end
@@ -921,6 +927,9 @@ function MR:PopulateConfigFrame(f)
     Checkbox("Hide Minimap Icon",
         function() return MR.db.profile.minimap and MR.db.profile.minimap.hide or false end,
         function(v) MR:SetMinimapHidden(v) end)
+    Checkbox("Minimize Down",
+        function() return MR.db.profile.minimizeDown end,
+        function(v) MR.db.profile.minimizeDown = v end)
 
     Gap(6)
     yOff = MR_OptionsSlider(body, yOff, "WIDTH", PANEL_MIN_WIDTH, PANEL_MAX_WIDTH, 10,


### PR DESCRIPTION
## Summary
- Adds a **Minimize Down** checkbox to the Options panel (alongside Collapse Completed, Lock Frame, Hide Minimap Icon)
- When enabled, clicking the minimize button collapses the frame to the **bottom** of its position instead of the top
- Uses `BOTTOMLEFT` anchoring so the frame naturally restores **upward** when un-minimized

## How it works
- New `minimizeDown` profile setting (defaults to `false`, persisted via AceDB)
- `ApplyMinimizeState()` checks the setting and anchors at `BOTTOMLEFT` with `f:GetBottom()` instead of `TOPLEFT` with `f:GetTop()`
- No behavior change when the option is unchecked — existing minimize behavior is untouched

## Test plan
- [x] Open Options panel → verify "Minimize Down" checkbox appears below "Hide Minimap Icon"
- [x] With option **unchecked**: click minimize → frame collapses to header at the **top** (existing behavior)
- [x] With option **checked**: click minimize → frame collapses to header at the **bottom** of where it was
- [x] Un-minimize from both states → frame restores to full size correctly
- [x] Drag the minimized frame, then un-minimize → position is maintained
- [x] Setting persists across /reload