### PR TITLE
Allow unmarking manually-completed items from collapsed state

### DIFF
--- a/UI.lua
+++ b/UI.lua
@@ -706,9 +706,20 @@ function MR:BuildRow(mod, row, done, yOff, collapsed, xOff, colW)
             GameTooltip:SetOwner(rowFrame, "ANCHOR_RIGHT")
             GameTooltip:SetText("Done: " .. row.label, 0.4, 0.85, 0.4, 1, true)
             GameTooltip:AddLine("Completed this week", 0.3, 0.6, 0.3)
+            if not isAutoTracked then
+                GameTooltip:AddLine("Right-click: -1", 0.5, 0.5, 0.5)
+            end
             GameTooltip:Show()
         end)
         rowFrame:SetScript("OnLeave", function() GameTooltip:Hide() end)
+
+        if not isAutoTracked then
+            rowFrame:SetScript("OnMouseDown", function(_, button)
+                if button == "RightButton" then
+                    MR:BumpProgress(mod.key, row.key, -1, row.max)
+                end
+            end)
+        end
 
         table.insert(self.widgets, rowFrame)
         return yOff + rowH


### PR DESCRIPTION
## Summary
- Collapsed (hidden-complete) rows had no click handler or tooltip hint, making it impossible to undo an accidental manual completion without expanding the section first
- Adds a right-click handler on collapsed rows for manually-tracked items to decrement progress
- Shows "Right-click: -1" in the collapsed row tooltip so users know they can unmark

## Test plan
- [x] Enable "Collapse Completed" on a section with manually-tracked rows
- [x] Manually complete a row (left-click until max) — it collapses to a green dot/line
- [x] Hover the collapsed row — tooltip should show "Done: [name]", "Completed this week", and "Right-click: -1"
- [x] Right-click the collapsed row — it should decrement and uncollapse back to a normal row
- [x] Verify auto-tracked completed rows do NOT show the right-click hint or respond to clicks