### PR TITLE
Prevent long row labels from wrapping and overlapping rows

### DIFF
--- a/UI.lua
+++ b/UI.lua
@@ -766,6 +766,7 @@ function MR:BuildRow(mod, row, done, yOff, collapsed, xOff, colW)
     lbl:SetPoint("LEFT",  rowFrame, "LEFT",  PADDING + 10, 0)
     lbl:SetPoint("RIGHT", rowFrame, "RIGHT", -52, 0)
     lbl:SetJustifyH("LEFT")
+    lbl:SetWordWrap(false)
     lbl:SetText(row.label)
     if isComplete then lbl:SetTextColor(0.38, 0.38, 0.38) end
 


### PR DESCRIPTION
## Summary
- Long row labels (e.g. "Weekly Gather – Septarian Nodule") word-wrap into a second line while the row frame keeps its fixed height, causing text to visually overlap subsequent rows
- Disables word wrapping on row labels so they truncate cleanly within the available space
- Full label text remains visible in the tooltip on hover

## Test plan
- [x] Resize the panel to a narrow width where labels like "Weekly Gather – Septarian Nodule" would previously wrap
- [x] Verify long labels now truncate instead of wrapping
- [x] Hover over a truncated label to confirm the full text shows in the tooltip
- [x] Verify rows no longer overlap when labels are long