### PR TITLE
Migrate framework from Ace3 to Foundry-1.0

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -7,12 +7,7 @@ externals:
   Libs/LibDBIcon-1.0: https://repos.wowace.com/wow/libdbicon-1-0/trunk/LibDBIcon-1.0
   Libs/LibDataBroker-1.1: https://github.com/tekkub/libdatabroker-1-1.git
   Libs/LibStub: https://repos.curseforge.com/wow/libstub/trunk
-  Libs/AceAddon-3.0: https://repos.curseforge.com/wow/ace3/trunk/AceAddon-3.0
-  Libs/AceBucket-3.0: https://repos.curseforge.com/wow/ace3/trunk/AceBucket-3.0
-  Libs/AceDB-3.0: https://repos.curseforge.com/wow/ace3/trunk/AceDB-3.0
-  Libs/AceEvent-3.0: https://repos.curseforge.com/wow/ace3/trunk/AceEvent-3.0
   Libs/AceLocale-3.0: https://repos.curseforge.com/wow/ace3/trunk/AceLocale-3.0
-  Libs/AceTimer-3.0: https://repos.curseforge.com/wow/ace3/trunk/AceTimer-3.0
 
 ignore:
   - .github

--- a/Core.lua
+++ b/Core.lua
@@ -1,13 +1,36 @@
 local addonName, ns = ...
 
 local LibStub  = LibStub
-local AceAddon = LibStub("AceAddon-3.0")
-local AceDB    = LibStub("AceDB-3.0")
 local L        = LibStub("AceLocale-3.0"):GetLocale(addonName)
 
-local MR = AceAddon:NewAddon(addonName, "AceEvent-3.0", "AceBucket-3.0", "AceTimer-3.0")
+local F = _G.Foundry_1_0
+if not F then
+    error(addonName .. " failed to load Foundry-1.0.", 0)
+end
+
+local MR = {}
 ns.MR = MR
 MR.ns = ns
+
+-- Foundry.Lifecycle replaces AceAddon:NewAddon's lifecycle wiring. There is no
+-- combined "DB ready" hook (see Foundry/Modules/Lifecycle.lua header comment) --
+-- MR:OnInitialize constructs self.db itself, at the same OnAddonLoaded timing
+-- AceAddon's OnInitialize used to fire at.
+local Lifecycle = F.Lifecycle:New(MR, addonName)
+
+Lifecycle:OnAddonLoaded(function()
+    MR:OnInitialize()
+end)
+
+Lifecycle:OnLogin(function()
+    MR:OnEnable()
+end)
+
+-- Foundry.Events replaces the AceEvent-3.0 mixin: one controller owns this
+-- addon's frame-event registrations for the addon's lifetime (there is no
+-- runtime enable/disable to tear it down against).
+local Events = F.Events:New(addonName)
+MR.Events = Events
 
 local MODULES_WITH_OPTIONAL_CURRENCY_COMPLETION = {
     currencies = true,
@@ -251,8 +274,8 @@ function MR:QueueCombatDeferredUpdate(flag)
     self._combatDeferred = self._combatDeferred or {}
     self._combatDeferred[flag] = true
 
-    if self.RegisterEvent then
-        self:RegisterEvent("PLAYER_REGEN_ENABLED", "OnCombatEnded")
+    if not Events:IsRegistered("PLAYER_REGEN_ENABLED") then
+        Events:Register("PLAYER_REGEN_ENABLED", function() MR:OnCombatEnded() end)
     end
 end
 
@@ -345,9 +368,7 @@ function MR:FlushCombatDeferredUpdates()
 end
 
 function MR:OnCombatEnded()
-    if self.UnregisterEvent then
-        self:UnregisterEvent("PLAYER_REGEN_ENABLED")
-    end
+    Events:Unregister("PLAYER_REGEN_ENABLED")
 
     self:FlushCombatDeferredUpdates()
 end
@@ -605,7 +626,6 @@ end
 
 function MR:GetProgressBucket(moduleKey, rowKey)
     if moduleKey == "custom_tasks" and self.IsCustomTaskAccountWideCompletion and self:IsCustomTaskAccountWideCompletion(rowKey) then
-        self.db.global = self.db.global or {}
         self.db.global.customTaskProgress = self.db.global.customTaskProgress or {}
         return self.db.global.customTaskProgress
     end
@@ -615,7 +635,6 @@ end
 
 function MR:GetManualOverrideBucket(moduleKey, rowKey)
     if moduleKey == "custom_tasks" and self.IsCustomTaskAccountWideCompletion and self:IsCustomTaskAccountWideCompletion(rowKey) then
-        self.db.global = self.db.global or {}
         self.db.global.customTaskManualOverrides = self.db.global.customTaskManualOverrides or {}
         return self.db.global.customTaskManualOverrides
     end
@@ -1094,25 +1113,20 @@ function MR:SetModuleEnabled(key, enabled, skipRefresh)
 end
 
 function MR:RequestUIRefresh(delay)
-    if not self.ScheduleTimer then
-        self:RefreshUI()
-        return
-    end
-
     delay = tonumber(delay) or 0.05
     self._refreshRequestPending = true
-    if self._refreshRequestTimer and self.CancelTimer then
-        self:CancelTimer(self._refreshRequestTimer)
+    if self._refreshRequestTimer then
+        self._refreshRequestTimer:Cancel()
         self._refreshRequestTimer = nil
     end
 
-    self._refreshRequestTimer = self:ScheduleTimer(function()
+    self._refreshRequestTimer = C_Timer.NewTimer(delay, function()
         self._refreshRequestTimer = nil
         if self._refreshRequestPending then
             self._refreshRequestPending = nil
             self:RefreshUI()
         end
-    end, delay)
+    end)
 end
 
 function MR:RequestConfigRefresh()
@@ -1751,12 +1765,12 @@ function MR:RequestScan(delay)
 
     if delay > 0 then
         if self._requestedScanTimer then
-            self:CancelTimer(self._requestedScanTimer)
+            self._requestedScanTimer:Cancel()
         end
-        self._requestedScanTimer = self:ScheduleTimer(function()
+        self._requestedScanTimer = C_Timer.NewTimer(delay, function()
             self._requestedScanTimer = nil
             self:Scan()
-        end, delay)
+        end)
         return
     end
 
@@ -1814,7 +1828,6 @@ function MR:ScanAutoUpdateInstanceRows(changedQuestId, changedEncounterId, diffi
                         if self.db then
                             local diffProgress
                             if row.accountWideComplete then
-                                self.db.global = self.db.global or {}
                                 self.db.global.customTaskDiffProgress = self.db.global.customTaskDiffProgress or {}
                                 diffProgress = self.db.global.customTaskDiffProgress
                             elseif self.db.char then
@@ -2034,7 +2047,7 @@ function MR:Scan()
     local minScanInterval = 0.25
 
     if self._requestedScanTimer then
-        self:CancelTimer(self._requestedScanTimer)
+        self._requestedScanTimer:Cancel()
         self._requestedScanTimer = nil
     end
 
@@ -2047,13 +2060,13 @@ function MR:Scan()
         self._scanPending = true
         if not self._scanThrottleTimer then
             local delay = math.max(minScanInterval - (now - self._lastScanAt), 0.01)
-            self._scanThrottleTimer = self:ScheduleTimer(function()
+            self._scanThrottleTimer = C_Timer.NewTimer(delay, function()
                 self._scanThrottleTimer = nil
                 if self._scanPending then
                     self._scanPending = nil
                     self:Scan()
                 end
-            end, delay)
+            end)
         end
         return
     end
@@ -2131,10 +2144,10 @@ function MR:Scan()
 
     if self._scanPending and not self._scanThrottleTimer then
         self._scanPending = nil
-        self._scanThrottleTimer = self:ScheduleTimer(function()
+        self._scanThrottleTimer = C_Timer.NewTimer(minScanInterval, function()
             self._scanThrottleTimer = nil
             self:Scan()
-        end, minScanInterval)
+        end)
     end
 end
 
@@ -2175,7 +2188,12 @@ function MR:RebuildTurnInCompletions()
 end
 
 function MR:OnInitialize()
-    self.db = AceDB:New("MidnightRoutineDB", DEFAULTS, true)
+    self.db = F.DB:New({
+        name = addonName,
+        sv = "MidnightRoutineDB",
+        defaultProfile = true,
+        defaults = DEFAULTS,
+    })
     self:MigrateLegacySettings()
     if self.RefreshCustomTasksModule then
         self:RefreshCustomTasksModule()
@@ -2465,50 +2483,66 @@ function MR:UpdateInstanceFrameVisibility()
 end
 
 function MR:OnEnable()
-    self:RegisterBucketEvent({
-        "AREA_POIS_UPDATED",
-    }, 0.75, "OnAreaPoisUpdated")
+    Events:RegisterBucket({
+        events = "AREA_POIS_UPDATED",
+        interval = 0.75,
+        handler = function() MR:OnAreaPoisUpdated() end,
+    })
 
-    self:RegisterBucketEvent({
-        "QUEST_LOG_UPDATE",
-        "UNIT_QUEST_LOG_CHANGED",
-        "GOSSIP_SHOW",
-        "GOSSIP_CLOSED",
-        "QUEST_DETAIL",
-        "QUEST_DATA_LOAD_RESULT",
-        "QUEST_PROGRESS",
-        "QUEST_COMPLETE",
-    }, 0.5, "OnQuestDataChanged")
+    Events:RegisterBucket({
+        events = {
+            "QUEST_LOG_UPDATE",
+            "UNIT_QUEST_LOG_CHANGED",
+            "GOSSIP_SHOW",
+            "GOSSIP_CLOSED",
+            "QUEST_DETAIL",
+            "QUEST_DATA_LOAD_RESULT",
+            "QUEST_PROGRESS",
+            "QUEST_COMPLETE",
+        },
+        interval = 0.5,
+        handler = function() MR:OnQuestDataChanged() end,
+    })
 
-    self:RegisterBucketEvent({
-        "SKILL_LINES_CHANGED",
-        "TRADE_SKILL_LIST_UPDATE",
-        "SKILL_LINE_SPECS_RANKS_CHANGED",
-        "TRADE_SKILL_SHOW",
-    }, 1, "OnProfessionChange")
+    Events:RegisterBucket({
+        events = {
+            "SKILL_LINES_CHANGED",
+            "TRADE_SKILL_LIST_UPDATE",
+            "SKILL_LINE_SPECS_RANKS_CHANGED",
+            "TRADE_SKILL_SHOW",
+        },
+        interval = 1,
+        handler = function() MR:OnProfessionChange() end,
+    })
 
-    self:RegisterBucketEvent({
-        "ZONE_CHANGED_NEW_AREA",
-    }, 0.5, "OnZoneChanged")
+    Events:RegisterBucket({
+        events = "ZONE_CHANGED_NEW_AREA",
+        interval = 0.5,
+        handler = function() MR:OnZoneChanged() end,
+    })
 
-    self:RegisterBucketEvent({
-        "CHALLENGE_MODE_COMPLETED",
-        "WEEKLY_REWARDS_UPDATE",
-        "LFG_COMPLETION_REWARD",
-    }, 1, "OnVaultEvent")
+    Events:RegisterBucket({
+        events = {
+            "CHALLENGE_MODE_COMPLETED",
+            "WEEKLY_REWARDS_UPDATE",
+            "LFG_COMPLETION_REWARD",
+        },
+        interval = 1,
+        handler = function() MR:OnVaultEvent() end,
+    })
 
-    self:RegisterEvent("UNIT_SPELLCAST_SUCCEEDED", "OnSpellCast")
-    self:RegisterEvent("ENCOUNTER_END",            "OnEncounterEnd")
-    self:RegisterEvent("BOSS_KILL",                "OnBossKill")
-    self:RegisterEvent("CURRENCY_DISPLAY_UPDATE",  "OnCurrencyDisplayUpdate")
-    self:RegisterEvent("QUEST_TURNED_IN",          "OnQuestTurnedIn")
-    self:RegisterEvent("QUEST_ACCEPTED",           "OnQuestAccepted")
-    self:RegisterEvent("QUEST_REMOVED",            "OnQuestRemoved")
-    self:RegisterEvent("BAG_UPDATE_DELAYED",       "OnBagUpdateDelayed")
-    self:RegisterEvent("PLAYER_ENTERING_WORLD",    "OnEnteringWorld")
+    Events:Register("UNIT_SPELLCAST_SUCCEEDED", function(...) MR:OnSpellCast(...) end)
+    Events:Register("ENCOUNTER_END",            function(...) MR:OnEncounterEnd(...) end)
+    Events:Register("BOSS_KILL",                function(...) MR:OnBossKill(...) end)
+    Events:Register("CURRENCY_DISPLAY_UPDATE",  function(...) MR:OnCurrencyDisplayUpdate(...) end)
+    Events:Register("QUEST_TURNED_IN",          function(...) MR:OnQuestTurnedIn(...) end)
+    Events:Register("QUEST_ACCEPTED",           function(...) MR:OnQuestAccepted(...) end)
+    Events:Register("QUEST_REMOVED",            function(...) MR:OnQuestRemoved(...) end)
+    Events:Register("BAG_UPDATE_DELAYED",       function(...) MR:OnBagUpdateDelayed(...) end)
+    Events:Register("PLAYER_ENTERING_WORLD",    function(...) MR:OnEnteringWorld(...) end)
 
-    self:ScheduleRepeatingTimer("CheckWeeklyReset", 60)
-    self:ScheduleRepeatingTimer("CheckDailyReset",  60)
+    C_Timer.NewTicker(60, function() MR:CheckWeeklyReset() end)
+    C_Timer.NewTicker(60, function() MR:CheckDailyReset() end)
 
     if not self._questTurnInFrame then
         local addon = self
@@ -2541,6 +2575,22 @@ function MR:OnEnable()
             addon:RefreshUI()
         end)
         self._questTurnInFrame = f
+    end
+
+    -- MinimapButton.lua's login-gated setup can't register its own
+    -- Foundry.Lifecycle OnLogin hook (one hook per phase per controller,
+    -- and this controller's login phase already runs MR:OnEnable) -- so it
+    -- is chained here instead.
+    if self.InitMinimapButton then
+        self:InitMinimapButton()
+    end
+
+    -- ProfessionKnowledge.lua's login-gated setup can't register its own
+    -- Foundry.Lifecycle OnLogin hook either (same one-hook-per-phase
+    -- limitation) -- chained here for the same reason as InitMinimapButton
+    -- above.
+    if self.InitProfessionKnowledge then
+        self:InitProfessionKnowledge()
     end
 end
 
@@ -2590,11 +2640,15 @@ function MR:OnEnteringWorld()
 
     self:MaybeShowWelcomeScreen()
     if self.OnRenownUpdate and not self._renownUpdateBucketHandle then
-        self._renownUpdateBucketHandle = self:RegisterBucketEvent({
-            "MAJOR_FACTION_RENOWN_LEVEL_CHANGED",
-            "UPDATE_FACTION",
-            "COMBAT_TEXT_UPDATE",
-        }, 1, "OnRenownUpdate")
+        self._renownUpdateBucketHandle = Events:RegisterBucket({
+            events = {
+                "MAJOR_FACTION_RENOWN_LEVEL_CHANGED",
+                "UPDATE_FACTION",
+                "COMBAT_TEXT_UPDATE",
+            },
+            interval = 1,
+            handler = function() MR:OnRenownUpdate() end,
+        })
     end
     if not shouldHideFrames and not temporarilyHidden and not self:IsManagedWindowsBundleHidden() then
         if self:GetManagedWindowOpen("renownOpen") and self.EnsureRenownShown then
@@ -2612,17 +2666,17 @@ function MR:OnEnteringWorld()
     end
     if self.db.profile.peekOnHover and self.ApplyPeekOnHover then
         if self._enteringWorldPeekTimer then
-            self:CancelTimer(self._enteringWorldPeekTimer)
+            self._enteringWorldPeekTimer:Cancel()
         end
-        self._enteringWorldPeekTimer = self:ScheduleTimer(function()
+        self._enteringWorldPeekTimer = C_Timer.NewTimer(2.5, function()
             self._enteringWorldPeekTimer = nil
             self:ApplyPeekOnHover(true)
-        end, 2.5)
+        end)
     end
     if self._enteringWorldRefreshTimer then
-        self:CancelTimer(self._enteringWorldRefreshTimer)
+        self._enteringWorldRefreshTimer:Cancel()
     end
-    self._enteringWorldRefreshTimer = self:ScheduleTimer(function()
+    self._enteringWorldRefreshTimer = C_Timer.NewTimer(0.5, function()
         self._enteringWorldRefreshTimer = nil
         self:CheckWeeklyReset()
         self:CheckDailyReset()
@@ -2632,14 +2686,14 @@ function MR:OnEnteringWorld()
         if self.RefreshGatheringLocationsFrame then
             self:RefreshGatheringLocationsFrame()
         end
-    end, 0.5)
+    end)
     if self._enteringWorldScanTimer then
-        self:CancelTimer(self._enteringWorldScanTimer)
+        self._enteringWorldScanTimer:Cancel()
     end
-    self._enteringWorldScanTimer = self:ScheduleTimer(function()
+    self._enteringWorldScanTimer = C_Timer.NewTimer(5, function()
         self._enteringWorldScanTimer = nil
         self:RequestScan()
-    end, 5)
+    end)
     self:RequestScan(0.35)
 end
 
@@ -2652,12 +2706,12 @@ function MR:OnCurrencyDisplayUpdate(_, currencyID)
 
     if currencyID == 3290 and self.RefreshDelvesLiveProgress then
         if self._delvesLiveProgressTimer then
-            self:CancelTimer(self._delvesLiveProgressTimer)
+            self._delvesLiveProgressTimer:Cancel()
         end
-        self._delvesLiveProgressTimer = self:ScheduleTimer(function()
+        self._delvesLiveProgressTimer = C_Timer.NewTimer(2, function()
             self._delvesLiveProgressTimer = nil
             self:RefreshDelvesLiveProgress(true)
-        end, 2)
+        end)
     end
 
     if dirty then
@@ -2810,63 +2864,128 @@ function MR:OnBossKill(_, bossId, bossName)
     self:RefreshModuleScans({ "world_bosses", "great_vault", "s1_weekly" }, true)
 end
 
-SLASH_MIDROUTE1 = "/mr"
-SLASH_MIDROUTE2 = "/midroute"
-SlashCmdList["MIDROUTE"] = function(msg)
-    msg = (msg or ""):lower():trim()
-    local function ApplyMainScale(value)
-        if MR.db.profile.syncWindowScale and MR.ApplyScaleToAll then
-            MR:ApplyScaleToAll(value)
-        else
-            MR.db.profile.scale = value
-            if MR.frame then MR.frame:SetScale(value) end
-        end
+-- Foundry.Commands replaces the manual SlashCmdList/SLASH_MIDROUTEn dispatch
+-- table. Longest-prefix, word-boundary matching means a two-word alias like
+-- "main toggle" is not registered as its own subcommand name -- it is the
+-- base word ("main") registered once, with the handler switching on the
+-- trimmed remainder. This preserves the original if/elseif chain's behavior,
+-- including its exact-match semantics: an unrecognized remainder (e.g.
+-- "main foobar") falls through to the same Chat_Commands message the
+-- original's final `else` printed for any unmatched full command.
+local function ApplyMainScale(value)
+    if MR.db.profile.syncWindowScale and MR.ApplyScaleToAll then
+        MR:ApplyScaleToAll(value)
+    else
+        MR.db.profile.scale = value
+        if MR.frame then MR.frame:SetScale(value) end
     end
+end
 
-    if msg == "reset" then
-        MR:DoWeeklyReset()
-    elseif msg == "lock" then
+-- Wraps a no-argument leaf command so it only fires on an exact match (no
+-- trailing remainder), matching the original chain's exact-string elseif
+-- checks (e.g. "/mr lock foo" fell through to the unknown-command message,
+-- not into "lock").
+local function ExactOnly(fn)
+    return function(rest)
+        if rest ~= "" then
+            print(L["Chat_Commands"])
+            return
+        end
+        fn()
+    end
+end
+
+local Commands = F.Commands:New({
+    name = "MidRoute",
+    slashes = { "/mr", "/midroute" },
+    defaultHandler = function() print(L["Chat_Commands"]) end,
+    unknownMessage = function() return L["Chat_Commands"] end,
+})
+MR.Commands = Commands
+
+Commands:Register({
+    name = "reset",
+    handler = ExactOnly(function() MR:DoWeeklyReset() end),
+})
+
+Commands:Register({
+    name = "lock",
+    handler = ExactOnly(function()
         MR.db.profile.locked = true
         if MR.frame then MR.frame:SetMovable(false) end
         print(L["Frame_Locked"])
-    elseif msg == "unlock" then
+    end),
+})
+
+Commands:Register({
+    name = "unlock",
+    handler = ExactOnly(function()
         MR.db.profile.locked = false
         if MR.frame then MR.frame:SetMovable(true) end
         print(L["Frame_Unlocked"])
-    elseif msg == "hide" then
+    end),
+})
+
+Commands:Register({
+    name = "hide",
+    handler = ExactOnly(function()
         if MR.frame then MR.frame:Hide() end
         MR.db.char.panelOpen = false
-    elseif msg == "show" then
+    end),
+})
+
+Commands:Register({
+    name = "show",
+    handler = ExactOnly(function()
         if MR.frame then MR.frame:Show() end
         MR.db.char.panelOpen = true
         MR:ClearManagedWindowsBundleHidden()
-    elseif msg == "toggle" then
-        MR:ToggleManagedWindows()
-    elseif msg == "main" or msg == "main toggle" then
-        if not MR.frame and MR.BuildUI then
-            MR:BuildUI()
-        end
-        if MR.frame then
-            if MR.frame:IsShown() then
-                MR.frame:Hide()
-                MR.db.char.panelOpen = false
-            else
-                MR.frame:Show()
-                MR.db.char.panelOpen = true
-                MR:ClearManagedWindowsBundleHidden()
+    end),
+})
+
+Commands:Register({
+    name = "toggle",
+    handler = ExactOnly(function() MR:ToggleManagedWindows() end),
+})
+
+Commands:Register({
+    name = "main",
+    args = "[show|hide]",
+    handler = function(rest)
+        rest = (rest or ""):lower()
+        if rest == "" or rest == "toggle" then
+            if not MR.frame and MR.BuildUI then
+                MR:BuildUI()
             end
+            if MR.frame then
+                if MR.frame:IsShown() then
+                    MR.frame:Hide()
+                    MR.db.char.panelOpen = false
+                else
+                    MR.frame:Show()
+                    MR.db.char.panelOpen = true
+                    MR:ClearManagedWindowsBundleHidden()
+                end
+            end
+        elseif rest == "show" then
+            if not MR.frame and MR.BuildUI then
+                MR:BuildUI()
+            end
+            if MR.frame then MR.frame:Show() end
+            MR.db.char.panelOpen = true
+            MR:ClearManagedWindowsBundleHidden()
+        elseif rest == "hide" then
+            if MR.frame then MR.frame:Hide() end
+            MR.db.char.panelOpen = false
+        else
+            print(L["Chat_Commands"])
         end
-    elseif msg == "main show" then
-        if not MR.frame and MR.BuildUI then
-            MR:BuildUI()
-        end
-        if MR.frame then MR.frame:Show() end
-        MR.db.char.panelOpen = true
-        MR:ClearManagedWindowsBundleHidden()
-    elseif msg == "main hide" then
-        if MR.frame then MR.frame:Hide() end
-        MR.db.char.panelOpen = false
-    elseif msg == "minimap" then
+    end,
+})
+
+Commands:Register({
+    name = "minimap",
+    handler = ExactOnly(function()
         local newHide = not (MR.db.profile.minimap and MR.db.profile.minimap.hide)
         MR:SetMinimapHidden(newHide)
         if newHide then
@@ -2874,24 +2993,75 @@ SlashCmdList["MIDROUTE"] = function(msg)
         else
             print(L["Minimap_Shown"])
         end
-    elseif msg == "scale" or msg == "scale toggle" then
-        local current = tonumber(MR.db.profile.scale) or 1.0
-        local target = math.abs(current - 0.5) < 0.001 and 2.0 or 0.5
-        ApplyMainScale(target)
-    elseif msg:match("^scale %d") then
-        local s = tonumber(msg:match("scale (%S+)"))
-        if s and s >= 0.5 and s <= 2 then
-            ApplyMainScale(s)
+    end),
+})
+
+Commands:Register({
+    name = "scale",
+    args = "[value]",
+    handler = function(rest)
+        rest = (rest or ""):lower()
+        if rest == "" or rest == "toggle" then
+            local current = tonumber(MR.db.profile.scale) or 1.0
+            local target = math.abs(current - 0.5) < 0.001 and 2.0 or 0.5
+            ApplyMainScale(target)
+        elseif rest:match("^%d") then
+            local s = tonumber(rest:match("^(%d+%.?%d*)"))
+            if s and s >= 0.5 and s <= 2 then
+                ApplyMainScale(s)
+            end
+        else
+            print(L["Chat_Commands"])
         end
-    elseif msg == "big" then if MR.ApplyWidth then MR.ApplyWidth(500) end
-    elseif msg == "small" then if MR.ApplyWidth then MR.ApplyWidth(200) end
-    elseif msg == "welcome" then MR:ShowWelcomeScreen()
-    elseif msg == "renown" then MR:ToggleRenown()
-    elseif msg == "renown config" then MR:ToggleRenownConfig()
-    elseif msg == "rares" then MR:ToggleRares()
-    elseif msg == "rares config" then MR:ToggleRaresConfig()
-    elseif msg == "gathering" then MR:ToggleGatheringLocations()
-    else
-        print(L["Chat_Commands"])
-    end
-end
+    end,
+})
+
+Commands:Register({
+    name = "big",
+    handler = ExactOnly(function() if MR.ApplyWidth then MR.ApplyWidth(500) end end),
+})
+
+Commands:Register({
+    name = "small",
+    handler = ExactOnly(function() if MR.ApplyWidth then MR.ApplyWidth(200) end end),
+})
+
+Commands:Register({
+    name = "welcome",
+    handler = ExactOnly(function() MR:ShowWelcomeScreen() end),
+})
+
+Commands:Register({
+    name = "renown",
+    args = "[config]",
+    handler = function(rest)
+        rest = (rest or ""):lower()
+        if rest == "" then
+            MR:ToggleRenown()
+        elseif rest == "config" then
+            MR:ToggleRenownConfig()
+        else
+            print(L["Chat_Commands"])
+        end
+    end,
+})
+
+Commands:Register({
+    name = "rares",
+    args = "[config]",
+    handler = function(rest)
+        rest = (rest or ""):lower()
+        if rest == "" then
+            MR:ToggleRares()
+        elseif rest == "config" then
+            MR:ToggleRaresConfig()
+        else
+            print(L["Chat_Commands"])
+        end
+    end,
+})
+
+Commands:Register({
+    name = "gathering",
+    handler = ExactOnly(function() MR:ToggleGatheringLocations() end),
+})

--- a/Core/Warband.lua
+++ b/Core/Warband.lua
@@ -79,16 +79,19 @@ end
 
 
 function MR:GetCurrentCharacterKey()
-    if self.db and self.db.keys and self.db.keys.char then
-        return self.db.keys.char
-    end
-
-    local name, realm = UnitFullName and UnitFullName("player")
+    -- Foundry.DB has no db.keys introspection surface (unlike AceDB) — even
+    -- referencing self.db.keys raises, so this is the only path now. Must match
+    -- Foundry.DB's own resolveCharKey() exactly (UnitName .. " - " .. GetRealmName,
+    -- the same formula AceDB used) since self.db.sv.char is keyed by that function,
+    -- not by this one — UnitFullName is a different API with no guarantee its
+    -- output matches, and using it here would silently break sv.char lookups.
+    local name = UnitName and UnitName("player")
+    local realm = GetRealmName and GetRealmName()
     if name and realm and realm ~= "" then
         return string.format("%s - %s", name, realm)
     end
 
-    return UnitName and UnitName("player") or "Unknown"
+    return name or "Unknown"
 end
 
 function MR:GetMainFrameProgressSource()

--- a/MidnightRoutine.toc
+++ b/MidnightRoutine.toc
@@ -5,6 +5,7 @@
 ## Author: Azro
 ## Version: @project-version@
 ## SavedVariables: MidnightRoutineDB
+## Dependencies: Foundry-1.0
 ## OptionalDeps: Blizzard_Professions
 ## IconTexture: Interface\AddOns\MidnightRoutine\Media\Icon
 ## X-Curse-Project-ID: 1472162
@@ -14,11 +15,6 @@
 Libs/LibStub/LibStub.lua
 Libs/CallbackHandler-1.0/CallbackHandler-1.0.lua
 
-Libs/AceAddon-3.0/AceAddon-3.0.xml
-Libs/AceEvent-3.0/AceEvent-3.0.xml
-Libs/AceBucket-3.0/AceBucket-3.0.xml
-Libs/AceTimer-3.0/AceTimer-3.0.xml
-Libs/AceDB-3.0/AceDB-3.0.xml
 Libs/AceLocale-3.0/AceLocale-3.0.lua
 Libs/LibDataBroker-1.1/LibDataBroker-1.1.lua
 Libs/LibDBIcon-1.0/LibDBIcon-1.0.lua

--- a/MinimapButton.lua
+++ b/MinimapButton.lua
@@ -70,29 +70,32 @@ local minimapObject = LDB:NewDataObject("MidnightRoutine", {
     end,
 })
 
-local mmLoader = CreateFrame("Frame")
-mmLoader:RegisterEvent("PLAYER_LOGIN")
-mmLoader:SetScript("OnEvent", function(self)
-    self:UnregisterAllEvents()
-
-    if not MR.db or not MR.db.profile then
+-- Foundry.Lifecycle's controller allows exactly one raw OnLogin hook per
+-- controller (Core.lua already claims it for MR:OnEnable()), so this can't
+-- register a second OnLogin subscriber directly. Instead this becomes an
+-- OnEnable-time subscriber: Core.lua's OnEnable calls MR:InitMinimapButton()
+-- at login, the same "chain a module init off the single login hook" pattern
+-- Foundry-based addons use elsewhere. One-shot by construction (OnLogin only
+-- fires once), so no UnregisterAllEvents equivalent is needed.
+function MR:InitMinimapButton()
+    if not self.db or not self.db.profile then
         return
     end
 
-    MR.db.profile.minimap = MR.db.profile.minimap or { hide = false }
+    self.db.profile.minimap = self.db.profile.minimap or { hide = false }
 
     if not LDBIcon:IsRegistered("MidnightRoutine") then
-        LDBIcon:Register("MidnightRoutine", minimapObject, MR.db.profile.minimap)
+        LDBIcon:Register("MidnightRoutine", minimapObject, self.db.profile.minimap)
     end
 
-    if not MR.db.profile.firstSeen then
+    if not self.db.profile.firstSeen then
         C_Timer.After(2.0, function()
             if MR and MR.db and MR.db.profile and not MR.db.profile.firstSeen then
                 StartGlow()
             end
         end)
     end
-end)
+end
 
 function MR:SetMinimapHidden(hide)
     if not self.db or not self.db.profile then return end

--- a/Modules/Crests.lua
+++ b/Modules/Crests.lua
@@ -1,6 +1,8 @@
 local _, ns = ...
 local MR = ns.MR
 
+local F = _G.Foundry_1_0
+
 local CREST_CAP = 100
 local L = LibStub("AceLocale-3.0"):GetLocale("MidnightRoutine")
 local crestRows
@@ -381,9 +383,7 @@ MR:RegisterModule({
     rows = crestRows,
 })
 
-local itemCacheFrame = CreateFrame("Frame")
-itemCacheFrame:RegisterEvent("GET_ITEM_INFO_RECEIVED")
-itemCacheFrame:SetScript("OnEvent", function(_, _, itemID)
+F.Events:New("MidnightRoutine-Crests"):Register("GET_ITEM_INFO_RECEIVED", function(_, itemID)
     if itemID ~= 232875 then return end
     RefreshCrestItemLabels()
 end)

--- a/Modules/CurrencyBrowser.lua
+++ b/Modules/CurrencyBrowser.lua
@@ -1,6 +1,8 @@
 local _, ns = ...
 local MR = ns.MR
 
+local F = _G.Foundry_1_0
+
 local L = LibStub("AceLocale-3.0"):GetLocale("MidnightRoutine")
 
 local ROW_HEIGHT = 24
@@ -1159,9 +1161,7 @@ function MR:ToggleCurrencyBrowserFrame()
     end
 end
 
-local eventFrame = CreateFrame("Frame")
-eventFrame:RegisterEvent("CURRENCY_DISPLAY_UPDATE")
-eventFrame:SetScript("OnEvent", function()
+F.Events:New("MidnightRoutine-CurrencyBrowser"):Register("CURRENCY_DISPLAY_UPDATE", function()
     if MR.currencyBrowserFrame and MR.currencyBrowserFrame:IsShown() then
         MR:RefreshCurrencyBrowserFrame()
     end

--- a/Modules/CustomTasks.lua
+++ b/Modules/CustomTasks.lua
@@ -33,7 +33,6 @@ local function GetTaskStorage(scope)
 
     scope = NormalizeTaskScope(scope)
     if scope == TASK_SCOPE_SHARED then
-        MR.db.global = MR.db.global or {}
         MR.db.global.customTasks = MR.db.global.customTasks or {}
         MR.db.global.customTaskNextId = tonumber(MR.db.global.customTaskNextId) or 1
         return MR.db.global.customTasks
@@ -323,11 +322,11 @@ local function RequestQuestRewardData(questId)
 end
 
 local function QueueRewardRefresh()
-    if not (MR and MR.ScheduleTimer) or MR._customTaskRewardRefreshTimer then
+    if not MR or MR._customTaskRewardRefreshTimer then
         return
     end
 
-    MR._customTaskRewardRefreshTimer = MR:ScheduleTimer(function()
+    MR._customTaskRewardRefreshTimer = C_Timer.NewTimer(1.5, function()
         MR._customTaskRewardRefreshTimer = nil
         if MR.RefreshCustomTasksModule then
             MR:RefreshCustomTasksModule()
@@ -335,7 +334,7 @@ local function QueueRewardRefresh()
         if MR.RefreshUI then
             MR:RefreshUI()
         end
-    end, 1.5)
+    end)
 end
 
 local function GetQuestMoneyReward(questId)
@@ -426,7 +425,6 @@ local function GetAccountWideProgressStorage()
         return nil
     end
 
-    MR.db.global = MR.db.global or {}
     MR.db.global.customTaskProgress = MR.db.global.customTaskProgress or {}
     return MR.db.global.customTaskProgress
 end
@@ -436,14 +434,12 @@ local function GetAccountWideManualOverrideStorage()
         return nil
     end
 
-    MR.db.global = MR.db.global or {}
     MR.db.global.customTaskManualOverrides = MR.db.global.customTaskManualOverrides or {}
     return MR.db.global.customTaskManualOverrides
 end
 
 local function GetDiffProgressStorage(task)
     if task and task.accountWideComplete then
-        MR.db.global = MR.db.global or {}
         MR.db.global.customTaskDiffProgress = MR.db.global.customTaskDiffProgress or {}
         return MR.db.global.customTaskDiffProgress
     end
@@ -781,7 +777,6 @@ function MR:AddCustomTask(label, resetType, maxValue, questIds, allowManualQuest
 
     local taskId
     if scope == TASK_SCOPE_SHARED then
-        self.db.global = self.db.global or {}
         taskId = tonumber(self.db.global.customTaskNextId) or 1
         self.db.global.customTaskNextId = taskId + 1
     else
@@ -839,7 +834,6 @@ function MR:UpdateCustomTask(taskId, label, resetType, maxValue, questIds, allow
         end
 
         if scope == TASK_SCOPE_SHARED then
-            self.db.global = self.db.global or {}
             task.id = tonumber(self.db.global.customTaskNextId) or 1
             self.db.global.customTaskNextId = task.id + 1
         else

--- a/Modules/ProfessionKnowledge.lua
+++ b/Modules/ProfessionKnowledge.lua
@@ -1,6 +1,8 @@
 local _, ns = ...
 local MR = ns.MR
 
+local F = _G.Foundry_1_0
+
 local FONT_HEADERS = ns.FONT_HEADERS
 local FONT_ROWS = ns.FONT_ROWS
 local StyledFrame = ns.StyledFrame
@@ -508,15 +510,19 @@ local function SetGatheringWaypoint(entry)
     return false, "No waypoint API available"
 end
 
-local itemCacheFrame = CreateFrame("Frame")
-itemCacheFrame:RegisterEvent("GET_ITEM_INFO_RECEIVED")
-itemCacheFrame:RegisterEvent("QUEST_TURNED_IN")
-itemCacheFrame:RegisterEvent("QUEST_LOG_UPDATE")
-itemCacheFrame:SetScript("OnEvent", function(self, event, itemID)
-    if event == "GET_ITEM_INFO_RECEIVED" then
-        if not watchedItemIDs[itemID] then return end
-        if AllWatchedItemsCached() then self:UnregisterEvent("GET_ITEM_INFO_RECEIVED") end
-    end
+local itemCacheEvents = F.Events:New("MidnightRoutine-ProfessionKnowledge")
+
+itemCacheEvents:Register("GET_ITEM_INFO_RECEIVED", function(_, itemID)
+    if not watchedItemIDs[itemID] then return end
+    if AllWatchedItemsCached() then itemCacheEvents:Unregister("GET_ITEM_INFO_RECEIVED") end
+    if gatheringLocationsFrame and gatheringLocationsFrame:IsShown() then RebuildGatheringLocationsFrame() end
+end)
+
+itemCacheEvents:Register("QUEST_TURNED_IN", function()
+    if gatheringLocationsFrame and gatheringLocationsFrame:IsShown() then RebuildGatheringLocationsFrame() end
+end)
+
+itemCacheEvents:Register("QUEST_LOG_UPDATE", function()
     if gatheringLocationsFrame and gatheringLocationsFrame:IsShown() then RebuildGatheringLocationsFrame() end
 end)
 
@@ -1525,19 +1531,30 @@ function MR:RebuildGatheringLocationsFrame()
     if gatheringLocationsFrame and gatheringLocationsFrame:IsShown() then RebuildGatheringLocationsFrame() end
 end
 
-local eventFrame = CreateFrame("Frame")
-eventFrame:RegisterEvent("ADDON_LOADED")
-eventFrame:RegisterEvent("PLAYER_LOGIN")
-eventFrame:SetScript("OnEvent", function(_, event, addonName)
-    if event == "ADDON_LOADED" and addonName == "MidnightRoutine" then
-        if MR.db then
-            gatheringMinimized = MR.db.profile.gatheringMinimized or false
-        end
-        eventFrame:UnregisterEvent("ADDON_LOADED")
-    elseif event == "PLAYER_LOGIN" then
-        if MR.db and MR.GetManagedWindowOpen and MR:GetManagedWindowOpen("gatheringLocOpen") then
-            MR:ShowGatheringLocations()
-        end
-        eventFrame:UnregisterEvent("PLAYER_LOGIN")
+-- Foundry.Lifecycle's controller allows exactly one raw OnLogin hook per
+-- controller (Core.lua already claims it for MR:OnEnable()), so this can't
+-- register a second OnLogin subscriber directly. Instead this becomes an
+-- OnEnable-time subscriber: Core.lua's OnEnable calls MR:InitProfessionKnowledge()
+-- at login, the same "chain a module init off the single login hook" pattern
+-- used for MinimapButton.lua. One-shot by construction (OnLogin only fires
+-- once), so no unregister-equivalent teardown is needed.
+--
+-- gatheringMinimized timing: the original code read
+-- MR.db.profile.gatheringMinimized from an ADDON_LOADED-branch handler, which
+-- ran BEFORE PLAYER_LOGIN. Under Foundry, MR.db is constructed in
+-- MR:OnInitialize(), which Core.lua hooks to Lifecycle:OnAddonLoaded --
+-- strictly before Lifecycle:OnLogin fires MR:OnEnable() (see Core.lua's
+-- Foundry.Lifecycle wiring: addon-loaded and login are two distinct,
+-- sequentially-ordered WoW startup signals). So reading gatheringMinimized
+-- here, at OnEnable/login time, sees MR.db fully constructed with defaults --
+-- strictly safer than the original ADDON_LOADED-branch timing, which relied
+-- on incidental frame-registration ordering between AceAddon's internal
+-- ADDON_LOADED demux and this file's own frame.
+function MR:InitProfessionKnowledge()
+    if self.db then
+        gatheringMinimized = self.db.profile.gatheringMinimized or false
     end
-end)
+    if self.db and self.GetManagedWindowOpen and self:GetManagedWindowOpen("gatheringLocOpen") then
+        self:ShowGatheringLocations()
+    end
+end

--- a/Modules/StoryCampaign.lua
+++ b/Modules/StoryCampaign.lua
@@ -1,5 +1,6 @@
 local _, ns = ...
 local MR = ns.MR
+local F = _G.Foundry_1_0
 
 local registeredCampaigns = {}
 local SKIP_STATES = { [3] = true }
@@ -89,6 +90,6 @@ local function TryRegisterCampaigns()
     if didRegister and MR.RefreshUI then MR:RefreshUI() end
 end
 
-MR:RegisterEvent("PLAYER_LOGIN", function()
+F.Events:New("MidnightRoutine-StoryCampaign"):RegisterOnce("PLAYER_LOGIN", function()
     C_Timer.After(1, TryRegisterCampaigns)
 end)

--- a/UI.lua
+++ b/UI.lua
@@ -3659,13 +3659,13 @@ function MR:RefreshUI()
         self._refreshUIPending = true
         if not self._refreshUITimer then
             local delay = math.max(minRefreshInterval - (now - self._lastRefreshUIAt), 0.01)
-            self._refreshUITimer = self:ScheduleTimer(function()
+            self._refreshUITimer = C_Timer.NewTimer(delay, function()
                 self._refreshUITimer = nil
                 if self._refreshUIPending then
                     self._refreshUIPending = nil
                     self:RefreshUI()
                 end
-            end, delay)
+            end)
         end
         return
     end
@@ -3847,10 +3847,10 @@ function MR:RefreshUI()
 
     if self._refreshUIPending and not self._refreshUITimer then
         self._refreshUIPending = nil
-        self._refreshUITimer = self:ScheduleTimer(function()
+        self._refreshUITimer = C_Timer.NewTimer(minRefreshInterval, function()
             self._refreshUITimer = nil
             self:RefreshUI()
-        end, minRefreshInterval)
+        end)
     end
 
 end

--- a/UI/Config.lua
+++ b/UI/Config.lua
@@ -1,6 +1,8 @@
 local _, ns = ...
 local MR = ns.MR
 
+local F = _G.Foundry_1_0
+
 local cfgFrame
 local L = LibStub("AceLocale-3.0"):GetLocale("MidnightRoutine")
 
@@ -100,6 +102,11 @@ local function ReleaseConfigWidgetTree(frame)
         frame:SetScript("OnLeave", nil)
         frame:SetScript("OnMouseDown", nil)
         frame:SetScript("OnMouseUp", nil)
+
+        if frame.menuCtrl then
+            frame.menuCtrl:Destroy()
+            frame.menuCtrl = nil
+        end
     end
 
     frame:SetScript("OnUpdate", nil)
@@ -229,15 +236,6 @@ function MR:PopulateConfigFrame(f)
         row:SetPoint("TOPLEFT", body, "TOPLEFT", 8, yOff)
         row:SetSize(contentW, 26)
 
-        local measure = row:CreateFontString(nil, "OVERLAY")
-        measure:SetFont(FONT_ROWS, cfgFs, GetFontFlags())
-        local widestLabel = 0
-        for _, choice in ipairs(choices) do
-            measure:SetText(choice.label or "")
-            widestLabel = math.max(widestLabel, measure:GetStringWidth() or 0)
-        end
-        measure:Hide()
-
         local valueBtn = CreateFrame("Button", nil, row, "BackdropTemplate")
         valueBtn:SetSize(math.max(170, contentW - 28), 20)
         valueBtn:SetPoint("LEFT", row, "LEFT", 0, 0)
@@ -259,50 +257,6 @@ function MR:PopulateConfigFrame(f)
         caret:SetText("v")
         caret:SetTextColor(0.78, 0.90, 0.92)
 
-        local popup = CreateFrame("Frame", nil, UIParent, "BackdropTemplate")
-        popup:SetFrameStrata("DIALOG")
-        popup:SetFrameLevel(50)
-        popup:SetBackdrop(MakeBackdrop())
-        popup:SetBackdropColor(0.04, 0.09, 0.15, 0.98)
-        popup:SetBackdropBorderColor(0.18, 0.40, 0.45, 1)
-        popup:EnableMouseWheel(true)
-        popup:Hide()
-        popup.buttons = {}
-
-        local popupScroll = CreateFrame("ScrollFrame", nil, popup)
-        popupScroll:SetPoint("TOPLEFT", popup, "TOPLEFT", 3, -3)
-        popupScroll:SetPoint("BOTTOMRIGHT", popup, "BOTTOMRIGHT", -3, 3)
-        popupScroll:EnableMouseWheel(true)
-
-        local popupContent = CreateFrame("Frame", nil, popupScroll)
-        popupContent:SetSize(1, 1)
-        popupScroll:SetScrollChild(popupContent)
-
-        local scrollTrack = CreateFrame("Button", nil, popup, "BackdropTemplate")
-        scrollTrack:SetWidth(8)
-        scrollTrack:SetBackdrop(MakeBackdrop())
-        scrollTrack:SetBackdropColor(0.03, 0.07, 0.11, 0.95)
-        scrollTrack:SetBackdropBorderColor(0.12, 0.26, 0.32, 0.95)
-        scrollTrack:Hide()
-
-        local scrollThumb = CreateFrame("Button", nil, scrollTrack, "BackdropTemplate")
-        scrollThumb:SetWidth(8)
-        scrollThumb:SetBackdrop(MakeBackdrop())
-        scrollThumb:SetBackdropColor(0.20, 0.66, 0.63, 0.95)
-        scrollThumb:SetBackdropBorderColor(0.30, 0.88, 0.82, 1)
-        scrollThumb:Hide()
-
-        local dismiss = CreateFrame("Frame", nil, UIParent)
-        dismiss:SetAllPoints(UIParent)
-        dismiss:SetFrameStrata("DIALOG")
-        dismiss:SetFrameLevel(49)
-        dismiss:EnableMouse(true)
-        dismiss:Hide()
-        dismiss:SetScript("OnMouseDown", function()
-            popup:Hide()
-            dismiss:Hide()
-        end)
-
         local function ApplySelection(index, commit)
             currentIndex = index
             local selected = choices[currentIndex] or choices[1]
@@ -310,150 +264,6 @@ function MR:PopulateConfigFrame(f)
             if commit ~= false then
                 setVal(selected.value, selected)
             end
-        end
-
-        local function EnsurePopupButton(index)
-            local btn = popup.buttons[index]
-            if btn then
-                return btn
-            end
-
-            btn = CreateFrame("Button", nil, popupContent, "BackdropTemplate")
-            btn:SetHeight(18)
-            btn:SetBackdrop(MakeBackdrop())
-            btn:SetBackdropColor(0.05, 0.12, 0.20, 0.94)
-            btn:SetBackdropBorderColor(0.12, 0.26, 0.32, 0.95)
-
-            btn._label = btn:CreateFontString(nil, "OVERLAY")
-            btn._label:SetFont(FONT_ROWS, cfgFs, GetFontFlags())
-            btn._label:SetPoint("LEFT", btn, "LEFT", 8, 1)
-            btn._label:SetPoint("RIGHT", btn, "RIGHT", -22, 1)
-            btn._label:SetJustifyH("LEFT")
-
-            btn._check = btn:CreateFontString(nil, "OVERLAY")
-            btn._check:SetFont(FONT_HEADERS, 10, GetFontFlags())
-            btn._check:SetPoint("RIGHT", btn, "RIGHT", -7, 1)
-
-            btn:SetScript("OnEnter", function(selfBtn)
-                selfBtn:SetBackdropColor(0.08, 0.18, 0.28, 0.98)
-                selfBtn:SetBackdropBorderColor(0.26, 0.78, 0.72, 1)
-            end)
-            btn:SetScript("OnLeave", function(selfBtn)
-                local active = selfBtn._checked == true
-                selfBtn:SetBackdropColor(active and 0.10 or 0.05, active and 0.22 or 0.12, active and 0.30 or 0.20, active and 0.98 or 0.94)
-                selfBtn:SetBackdropBorderColor(active and 0.28 or 0.12, active and 0.86 or 0.26, active and 0.78 or 0.32, active and 1 or 0.95)
-            end)
-
-            popup.buttons[index] = btn
-            return btn
-        end
-
-        local function UpdatePopupScrollBar()
-            local viewH = popupScroll:GetHeight() or 0
-            local contentH = popupContent:GetHeight() or 0
-            local maxScroll = math.max(contentH - viewH, 0)
-            local current = math.max(0, math.min(popupScroll:GetVerticalScroll() or 0, maxScroll))
-
-            if current ~= (popupScroll:GetVerticalScroll() or 0) then
-                popupScroll:SetVerticalScroll(current)
-            end
-
-            if maxScroll <= 0 then
-                scrollTrack:Hide()
-                scrollThumb:Hide()
-                return
-            end
-
-            scrollTrack:Show()
-            local trackH = scrollTrack:GetHeight() or 0
-            local thumbH = math.max(18, math.floor(trackH * (viewH / math.max(contentH, 1))))
-            thumbH = math.min(thumbH, trackH)
-            scrollThumb:SetHeight(thumbH)
-
-            local travel = math.max(trackH - thumbH, 0)
-            local pct = current / math.max(maxScroll, 1)
-            scrollThumb:ClearAllPoints()
-            scrollThumb:SetPoint("TOP", scrollTrack, "TOP", 0, -travel * pct)
-            scrollThumb:Show()
-        end
-
-        local function SetPopupScrollFromCursor(cursorY, grabOffset)
-            local contentH = popupContent:GetHeight() or 0
-            local viewH = popupScroll:GetHeight() or 0
-            local maxScroll = math.max(contentH - viewH, 0)
-            if maxScroll <= 0 then
-                popupScroll:SetVerticalScroll(0)
-                UpdatePopupScrollBar()
-                return
-            end
-
-            local trackTop = select(2, scrollTrack:GetCenter())
-            local trackH = scrollTrack:GetHeight() or 0
-            local thumbH = scrollThumb:GetHeight() or 0
-            local cursorOffset = (trackTop + trackH * 0.5) - cursorY - (grabOffset or thumbH * 0.5)
-            local travel = math.max(trackH - thumbH, 1)
-            local pct = math.max(0, math.min(cursorOffset / travel, 1))
-            popupScroll:SetVerticalScroll(maxScroll * pct)
-            UpdatePopupScrollBar()
-        end
-
-        local function RefreshPopup()
-            local width = math.max(valueBtn:GetWidth(), math.ceil(widestLabel) + 52)
-            local rowHeight = 18
-            local spacing = 2
-            local visibleCount = #choices
-            local maxVisibleRows = 10
-            local needsScroll = visibleCount > maxVisibleRows
-            local shownRows = math.min(visibleCount, maxVisibleRows)
-            local scrollGutter = needsScroll and 12 or 0
-            popup:SetSize(width + scrollGutter, math.max(shownRows * (rowHeight + spacing) + 6, 24))
-            popupScroll:ClearAllPoints()
-            if needsScroll then
-                popupScroll:SetPoint("TOPLEFT", popup, "TOPLEFT", 3, -3)
-                popupScroll:SetPoint("BOTTOMRIGHT", popup, "BOTTOMRIGHT", -14, 3)
-                scrollTrack:ClearAllPoints()
-                scrollTrack:SetPoint("TOPRIGHT", popup, "TOPRIGHT", -3, -3)
-                scrollTrack:SetPoint("BOTTOMRIGHT", popup, "BOTTOMRIGHT", -3, 3)
-            else
-                popupScroll:SetPoint("TOPLEFT", popup, "TOPLEFT", 3, -3)
-                popupScroll:SetPoint("BOTTOMRIGHT", popup, "BOTTOMRIGHT", -3, 3)
-                scrollTrack:Hide()
-                scrollThumb:Hide()
-            end
-
-            local contentWidth = math.max(width - 6, 1)
-            local contentHeight = math.max(visibleCount * (rowHeight + spacing) - spacing + 6, 1)
-            popupContent:SetSize(contentWidth, contentHeight)
-
-            for index, choice in ipairs(choices) do
-                local btn = EnsurePopupButton(index)
-                btn:ClearAllPoints()
-                btn:SetPoint("TOPLEFT", popupContent, "TOPLEFT", 0, -3 - (index - 1) * (rowHeight + spacing))
-                btn:SetPoint("TOPRIGHT", popupContent, "TOPRIGHT", 0, -3 - (index - 1) * (rowHeight + spacing))
-                btn:SetHeight(rowHeight)
-                btn._label:SetFont(FONT_ROWS, cfgFs, GetFontFlags())
-                btn._check:SetFont(FONT_HEADERS, 10, GetFontFlags())
-                btn._label:SetText(choice.label)
-                btn._check:SetText(index == currentIndex and "v" or "")
-                btn._checked = index == currentIndex
-                btn:SetBackdropColor(btn._checked and 0.10 or 0.05, btn._checked and 0.22 or 0.12, btn._checked and 0.30 or 0.20, btn._checked and 0.98 or 0.94)
-                btn:SetBackdropBorderColor(btn._checked and 0.28 or 0.12, btn._checked and 0.86 or 0.26, btn._checked and 0.78 or 0.32, btn._checked and 1 or 0.95)
-                btn:SetScript("OnClick", function()
-                    ApplySelection(index, true)
-                    popup:Hide()
-                    dismiss:Hide()
-                end)
-                btn:Show()
-            end
-
-            for index = visibleCount + 1, #popup.buttons do
-                popup.buttons[index]:Hide()
-            end
-
-            local selectedOffset = math.max(0, (currentIndex - 1) * (rowHeight + spacing))
-            local maxScroll = math.max(contentHeight - (popupScroll:GetHeight() or 0), 0)
-            popupScroll:SetVerticalScroll(math.max(0, math.min(selectedOffset, maxScroll)))
-            UpdatePopupScrollBar()
         end
 
         valueBtn:SetScript("OnEnter", function(selfBtn)
@@ -464,83 +274,38 @@ function MR:PopulateConfigFrame(f)
             selfBtn:SetBackdropColor(0.05, 0.12, 0.20, 0.95)
             selfBtn:SetBackdropBorderColor(0.18, 0.40, 0.45, 1)
         end)
-        valueBtn:SetScript("OnClick", function()
-            if popup:IsShown() then
-                popup:Hide()
-                dismiss:Hide()
-                return
-            end
 
-            RefreshPopup()
-            popup:ClearAllPoints()
-            local left = valueBtn:GetLeft() or 0
-            local popupWidth = popup:GetWidth() or valueBtn:GetWidth()
-            local screenWidth = UIParent and UIParent:GetWidth() or 0
-            local xOffset = 0
-            if screenWidth > 0 and left + popupWidth > screenWidth - 12 then
-                xOffset = math.min(0, (screenWidth - 12) - (left + popupWidth))
-            end
-            if left + xOffset < 12 then
-                xOffset = 12 - left
-            end
-            popup:SetPoint("TOPLEFT", valueBtn, "BOTTOMLEFT", xOffset, -2)
-            dismiss:Show()
-            popup:Show()
-            UpdatePopupScrollBar()
-        end)
-
-        local function ScrollPopup(delta)
-            local current = popupScroll:GetVerticalScroll() or 0
-            local maxScroll = math.max((popupContent:GetHeight() or 0) - (popupScroll:GetHeight() or 0), 0)
-            if maxScroll <= 0 then
-                popupScroll:SetVerticalScroll(0)
-                UpdatePopupScrollBar()
-                return
-            end
-
-            popupScroll:SetVerticalScroll(math.max(0, math.min(current - delta * 24, maxScroll)))
-            UpdatePopupScrollBar()
+        -- Popup mechanism (overflow scroll, outside-click dismiss, anchor
+        -- clamping) is Foundry.Menu / Blizzard's native menu system. valueBtn
+        -- stays a plain custom BackdropTemplate button (not a DropdownButton),
+        -- so we drive the menu with :CreateContextMenu(owner) from OnClick
+        -- rather than :SetupDropdown (which requires the DropdownButtonMixin
+        -- SetupMenu API valueBtn does not have). Anonymous name: this widget
+        -- is rebuilt every PopulateConfigFrame call, so a stable name would
+        -- collide with the still-live controller from the previous populate.
+        if F then
+            local menuCtrl = F.Menu:New({
+                builder = function(_, rootDescription)
+                    rootDescription:CreateTitle(label)
+                    for index, choice in ipairs(choices) do
+                        rootDescription:CreateRadio(choice.label, function()
+                            return index == currentIndex
+                        end, function()
+                            ApplySelection(index, true)
+                        end)
+                    end
+                end,
+            })
+            -- Stored on valueBtn so ReleaseConfigWidgetTree can :Destroy() it on
+            -- teardown -- this widget is rebuilt every PopulateConfigFrame call,
+            -- and an undestroyed anonymous controller leaks its liveKeys entry.
+            valueBtn.menuCtrl = menuCtrl
+            valueBtn:SetScript("OnClick", function()
+                if menuCtrl then
+                    menuCtrl:CreateContextMenu(valueBtn)
+                end
+            end)
         end
-
-        popup:SetScript("OnMouseWheel", function(_, delta)
-            ScrollPopup(delta)
-        end)
-        popupScroll:SetScript("OnMouseWheel", function(_, delta)
-            ScrollPopup(delta)
-        end)
-        popupScroll:SetScript("OnScrollRangeChanged", UpdatePopupScrollBar)
-        popupScroll:SetScript("OnVerticalScroll", UpdatePopupScrollBar)
-
-        scrollTrack:SetScript("OnMouseDown", function(_, button)
-            if button ~= "LeftButton" then
-                return
-            end
-
-            local _, cursorY = GetCursorPosition()
-            local scale = UIParent and UIParent:GetEffectiveScale() or 1
-            SetPopupScrollFromCursor(cursorY / scale, scrollThumb:GetHeight() * 0.5)
-        end)
-
-        scrollThumb:RegisterForDrag("LeftButton")
-        scrollThumb:SetScript("OnDragStart", function(selfBtn)
-            local _, cursorY = GetCursorPosition()
-            local scale = UIParent and UIParent:GetEffectiveScale() or 1
-            local thumbCenterY = select(2, selfBtn:GetCenter()) or 0
-            local thumbTopY = thumbCenterY + (selfBtn:GetHeight() or 0) * 0.5
-            selfBtn._grabOffset = thumbTopY - (cursorY / scale)
-        end)
-        scrollThumb:SetScript("OnDragStop", function(selfBtn)
-            selfBtn._grabOffset = nil
-        end)
-        scrollThumb:SetScript("OnUpdate", function(selfBtn)
-            if not selfBtn._grabOffset then
-                return
-            end
-
-            local _, cursorY = GetCursorPosition()
-            local scale = UIParent and UIParent:GetEffectiveScale() or 1
-            SetPopupScrollFromCursor(cursorY / scale, selfBtn._grabOffset)
-        end)
 
         local resetBtn = CreateFrame("Button", nil, row, "BackdropTemplate")
         resetBtn:SetSize(20, 20)
@@ -560,12 +325,10 @@ function MR:PopulateConfigFrame(f)
             for index, choice in ipairs(choices) do
                 if choice.value == resetValue then
                     ApplySelection(index, true)
-                    RefreshPopup()
                     return
                 end
             end
             ApplySelection(1, true)
-            RefreshPopup()
         end)
 
         ApplySelection(currentIndex, false)
@@ -2095,26 +1858,21 @@ function MR:RequestConfigRepopulate(frame, delay)
         return
     end
 
-    if not self.ScheduleTimer then
-        self:PopulateConfigFrame(frame)
-        return
-    end
-
     delay = tonumber(delay) or 0.04
     self._configRepopulatePendingFrame = frame
-    if self._configRepopulateTimer and self.CancelTimer then
-        self:CancelTimer(self._configRepopulateTimer)
+    if self._configRepopulateTimer then
+        self._configRepopulateTimer:Cancel()
         self._configRepopulateTimer = nil
     end
 
-    self._configRepopulateTimer = self:ScheduleTimer(function()
+    self._configRepopulateTimer = C_Timer.NewTimer(delay, function()
         local target = self._configRepopulatePendingFrame
         self._configRepopulateTimer = nil
         self._configRepopulatePendingFrame = nil
         if target and target:IsShown() then
             self:PopulateConfigFrame(target)
         end
-    end, delay)
+    end)
 end
 
 function MR:RepopulateConfigFrame()

--- a/UI/EncounterJournalOverlay.lua
+++ b/UI/EncounterJournalOverlay.lua
@@ -115,10 +115,11 @@ do
         return false
     end
 
-    local ejHookFrame = CreateFrame("Frame")
-    ejHookFrame:RegisterEvent("ADDON_LOADED")
-    ejHookFrame:SetScript("OnEvent", function(_, event, arg1)
-        if event ~= "ADDON_LOADED" or arg1 ~= "Blizzard_EncounterJournal" then return end
+    local F = _G.Foundry_1_0
+    local ejEvents = F.Events:New("MidnightRoutine-EncounterJournalOverlay")
+    ejEvents:Register("ADDON_LOADED", function(_, arg1)
+        if arg1 ~= "Blizzard_EncounterJournal" then return end
+        ejEvents:Unregister("ADDON_LOADED")
 
         C_Timer.After(0.5, function()
             HookScrollBoxIfFound(EncounterJournal, 0)

--- a/UI/WarbandBoard.lua
+++ b/UI/WarbandBoard.lua
@@ -1,6 +1,8 @@
 local _, ns = ...
 local MR = ns.MR
 
+local F = _G.Foundry_1_0
+
 local L = LibStub("AceLocale-3.0"):GetLocale("MidnightRoutine")
 local FONT_ROWS = ns.FONT_ROWS
 local FONT_HEADERS = ns.FONT_HEADERS
@@ -309,28 +311,6 @@ local function BuildExpansionDropdown(parent, forAltBoard, opts)
     caret:SetTextColor(0.78, 0.90, 0.92)
     btn._caret = caret
 
-    local popup = CreateFrame("Frame", nil, UIParent, "BackdropTemplate")
-    popup:SetFrameStrata("DIALOG")
-    popup:SetFrameLevel(50)
-    popup:SetBackdrop(MakeBackdrop())
-    popup:SetBackdropColor(0.04, 0.09, 0.15, 0.98)
-    popup:SetBackdropBorderColor(0.18, 0.40, 0.45, 1)
-    popup:Hide()
-    popup.buttons = {}
-    btn._popup = popup
-
-    local dismiss = CreateFrame("Frame", nil, UIParent)
-    dismiss:SetAllPoints(UIParent)
-    dismiss:SetFrameStrata("DIALOG")
-    dismiss:SetFrameLevel(49)
-    dismiss:EnableMouse(true)
-    dismiss:Hide()
-    dismiss:SetScript("OnMouseDown", function()
-        popup:Hide()
-        dismiss:Hide()
-    end)
-    btn._dismiss = dismiss
-
     function btn:ApplyFonts()
         local fontSize = GetFontSize()
         local labelSize = opts.fontSize or math.max(8, fontSize - 1)
@@ -341,15 +321,6 @@ local function BuildExpansionDropdown(parent, forAltBoard, opts)
         end
         if self._caret then
             self._caret:SetFont(FONT_HEADERS, caretSize, GetFontFlags())
-        end
-
-        for _, row in ipairs(popup.buttons) do
-            if row._label then
-                row._label:SetFont(FONT_ROWS, labelSize, GetFontFlags())
-            end
-            if row._check then
-                row._check:SetFont(FONT_HEADERS, caretSize, GetFontFlags())
-            end
         end
     end
 
@@ -375,86 +346,44 @@ local function BuildExpansionDropdown(parent, forAltBoard, opts)
         self:Show()
     end
 
-    local function EnsurePopupButton(index)
-        local row = popup.buttons[index]
-        if row then
-            return row
-        end
-
-        row = CreateFrame("Button", nil, popup, "BackdropTemplate")
-        row:SetHeight(18)
-        row:SetBackdrop(MakeBackdrop())
-        row:SetBackdropColor(0.05, 0.12, 0.20, 0.94)
-        row:SetBackdropBorderColor(0.12, 0.26, 0.32, 0.95)
-
-        row._label = row:CreateFontString(nil, "OVERLAY")
-        row._label:SetFont(FONT_ROWS, opts.fontSize or 8, GetFontFlags())
-        row._label:SetPoint("LEFT", row, "LEFT", 8, 1)
-        row._label:SetPoint("RIGHT", row, "RIGHT", -22, 1)
-        row._label:SetJustifyH("LEFT")
-
-        row._check = row:CreateFontString(nil, "OVERLAY")
-        row._check:SetFont(FONT_HEADERS, 10, GetFontFlags())
-        row._check:SetPoint("RIGHT", row, "RIGHT", -7, 1)
-
-        row:SetScript("OnEnter", function(selfRow)
-            selfRow:SetBackdropColor(0.08, 0.18, 0.28, 0.98)
-            selfRow:SetBackdropBorderColor(0.26, 0.78, 0.72, 1)
+    -- Popup mechanism (overflow scroll, outside-click dismiss, anchor
+    -- clamping) is Foundry.Menu / Blizzard's native menu system -- see
+    -- UI/Config.lua's ChoiceDropdown conversion for the reference pattern.
+    -- Unlike ChoiceDropdown (rebuilt every PopulateConfigFrame call), this
+    -- button is built exactly once per parent: MR:BuildUI() and
+    -- MR:ToggleWarbandBoard() both gate frame construction behind
+    -- `if self.frame/self.altBoardFrame then ... return end`, so
+    -- BuildExpansionDropdown never re-runs for a given parent and this
+    -- controller lives for the addon session -- no :Destroy() teardown site
+    -- is needed (nothing in this file ever tears this frame down). An
+    -- anonymous name (omitted here) keeps the two call sites -- the main
+    -- board in UI.lua and the alt board in WarbandBoard.lua -- from
+    -- colliding on a shared stable name.
+    if F then
+        local menuCtrl = F.Menu:New({
+            builder = function(_, rootDescription)
+                local expansions = MR:GetSelectableExpansions()
+                local selectedKey = MR:GetSelectedExpansionKey(btn.forAltBoard)
+                for _, info in ipairs(expansions) do
+                    rootDescription:CreateRadio(info.shortLabel or info.label or info.key, function()
+                        return info.key == selectedKey
+                    end, function()
+                        MR:SetSelectedExpansionKey(info.key, btn.forAltBoard)
+                    end)
+                end
+            end,
+        })
+        btn.menuCtrl = menuCtrl
+        btn:SetScript("OnClick", function(selfBtn)
+            local expansions = MR:GetSelectableExpansions()
+            if #expansions <= 1 then
+                return
+            end
+            if menuCtrl then
+                menuCtrl:CreateContextMenu(selfBtn)
+            end
         end)
-        row:SetScript("OnLeave", function(selfRow)
-            local active = selfRow._checked == true
-            selfRow:SetBackdropColor(active and 0.10 or 0.05, active and 0.22 or 0.12, active and 0.30 or 0.20, active and 0.98 or 0.94)
-            selfRow:SetBackdropBorderColor(active and 0.28 or 0.12, active and 0.86 or 0.26, active and 0.78 or 0.32, active and 1 or 0.95)
-        end)
-
-        popup.buttons[index] = row
-        return row
     end
-
-    btn:SetScript("OnClick", function(selfBtn)
-        local expansions = MR:GetSelectableExpansions()
-        if #expansions <= 1 then
-            return
-        end
-
-        local selectedKey = MR:GetSelectedExpansionKey(selfBtn.forAltBoard)
-        local rowWidth = math.max(selfBtn:GetWidth(), 130)
-        popup:ClearAllPoints()
-        popup:SetPoint("TOPLEFT", selfBtn, "BOTTOMLEFT", 0, -4)
-        popup:SetSize(rowWidth, (#expansions * 20) + 6)
-
-        for index, info in ipairs(expansions) do
-            local row = EnsurePopupButton(index)
-            row:ClearAllPoints()
-            row:SetPoint("TOPLEFT", popup, "TOPLEFT", 3, -3 - ((index - 1) * 20))
-            row:SetSize(rowWidth - 6, 18)
-            row._checked = info.key == selectedKey
-            row._label:SetText(info.shortLabel or info.label or info.key)
-            row._label:SetTextColor(row._checked and 0.96 or 0.74, row._checked and 1.00 or 0.90, row._checked and 1.00 or 0.92)
-            row._check:SetText(row._checked and "x" or "")
-            row._check:SetTextColor(0.80, 0.94, 0.92)
-            row:SetBackdropColor(row._checked and 0.10 or 0.05, row._checked and 0.22 or 0.12, row._checked and 0.30 or 0.20, row._checked and 0.98 or 0.94)
-            row:SetBackdropBorderColor(row._checked and 0.28 or 0.12, row._checked and 0.86 or 0.26, row._checked and 0.78 or 0.32, row._checked and 1 or 0.95)
-            row:SetScript("OnClick", function()
-                MR:SetSelectedExpansionKey(info.key, selfBtn.forAltBoard)
-                popup:Hide()
-                dismiss:Hide()
-            end)
-            row:Show()
-        end
-
-        for index = #expansions + 1, #popup.buttons do
-            popup.buttons[index]:Hide()
-        end
-
-        if popup:IsShown() then
-            popup:Hide()
-            dismiss:Hide()
-        else
-            dismiss:Show()
-            popup:Show()
-        end
-    end)
 
     return btn
 end


### PR DESCRIPTION
Hey Azro — this is the Ace3 → Foundry-1.0 framework migration I mentioned. Foundry (https://github.com/Royaleint/Foundry, also on CurseForge) is our lightweight addon framework built on modern Blizzard APIs; this PR swaps Midnight Routine's framework layer onto it with no intended user-facing changes.

## What changed

- **Lifecycle** — AceAddon `OnInitialize`/`OnEnable` → `Foundry.Lifecycle` (same phases, native event wiring underneath)
- **Saved data** — AceDB → `Foundry.DB`. Same profile/char/global section semantics over the existing `MidnightRoutineDB` SavedVariables, so **existing user data loads unchanged** — no migration step, nothing invalidated
- **Events & buckets** — AceEvent/AceBucket → `Foundry.Events` (buckets become built-in debounced groups)
- **Timers** — AceTimer → thin `C_Timer` wrappers
- **Slash commands** — hand-wired `SlashCmdList` → `Foundry.Commands`. Two small robustness wins: `/mr` subcommands are now case-insensitive (`/mr main SHOW` works) and argument parsing tolerates trailing text (`/mr scale 1.5 foo` no longer errors)
- **Dropdowns** — the config panel choice dropdown and both WarbandBoard expansion pickers move to `Foundry.Menu` (wraps Blizzard's native `MenuUtil`: proper checkmarks, native dismissal, no flicker on rapid changes)
- **Kept as-is** — AceLocale (still the right tool for your locale tables), LibDBIcon/LibDataBroker, and every hand-rolled scroll/grid UI. Deliberately narrow scope: framework seams only, zero module-logic changes
- **Packaging** — the five retired Ace3 externals are dropped from `.pkgmeta` (smaller zip); LibStub/CallbackHandler/AceLocale/LibDataBroker/LibDBIcon remain

## One decision for you: how Foundry ships

The `.toc` currently declares `## Dependencies: Foundry-1.0` (separate addon install). Two ways to make that seamless for your users:

1. **CurseForge required-dependency relation** on the MR project — CF auto-installs Foundry alongside MR. Zero repo changes; this is how I run it.
2. **Embed it** — vendor `Foundry-1.0` under `Libs/` with an `embeds.xml` (the load-on-demand pattern; our other addons ship it this way). Happy to push that variant onto this branch if you prefer self-contained zips.

## Testing

Run in-game on Retail across the full surface: load/reload with SavedVariables round-trip, every `/mr` subcommand, minimap button + LDB tooltip, config panel (rapid-change flicker check on the new menus), custom tasks in both character and account scope (create/edit/delete + reward data), currency browser (scroll/add/remove/collapse/resize), renown/rares/profession knowledge persistence, both WarbandBoard dropdowns, and a pass over the remaining modules (weekly tasks, PvP, vault, crests, delves, timewalking, DMF, world events, story campaign, welcome screen, EJ overlay) — those are functionally untouched.

One heads-up unrelated to this PR: window z-ordering when dragging one MR window over another interleaves them (half in front, half behind). That predates this change — the movable frames never set `SetToplevel(true)` — and is a two-line fix I can send separately if you want it.

Note: the branch is rebased onto your current `main` (my working copy predated your last few pushes; the overlapping changes in `Core.lua`, the `.toc`, and `Modules/CustomTasks.lua` are reconciled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)